### PR TITLE
255 char limit for remarks. Provide summary of missing data

### DIFF
--- a/processor/BatchProcessor.py
+++ b/processor/BatchProcessor.py
@@ -299,8 +299,8 @@ class BatchProcessor:
             remarks = {}
             remarks["event"] = "no ad data inside some files"
             remarks["event_type"] = "missing"
-            remarks["files"] = [f.name for f in  wl_errors.error_files]
-            remarks["count"] = int(len(wl_errors.error_files))
+            remarks["examples"] = [f.name for f in  wl_errors.error_files[0:5]]
+            remarks["number_missing"] = int(len(wl_errors.error_files))
 
             batch.remarks = json.dumps(remarks)
 


### PR DESCRIPTION
V1 ad format (xml vast) has lots of these because no monitoring is setup to notify of the ad collection failing.