### PR TITLE
Remove duplicates

### DIFF
--- a/processor/management/commands/merge_duplicate_video_entries.py
+++ b/processor/management/commands/merge_duplicate_video_entries.py
@@ -1,12 +1,6 @@
-from typing import Optional
-
 from django.core.management.base import BaseCommand, CommandError
-from processor.models import Videos, Channels, CheckStatus
+from processor.models import Videos, Channels, CheckStatus, Ad_Found_WatchLog, Categories
 from django.db.models import Count
-from dataclasses import dataclass
-
-@dataclass
-class TopChoice:
 
 
 class Command(BaseCommand):
@@ -17,25 +11,31 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         dup_urls = Videos.objects.values("url").annotate(url_copies=Count("url")).filter(url_copies__gte=2).order_by('-url_copies')
-        print("length: ", len(dup_urls), dup_urls)
-
+        missing_channel_id: int = Channels.objects.only("id").get(name="missing").id
+        missing_category_id: int = Categories.objects.only("id").get(name="missing").id
+        print(f"all dups: {dup_urls}")
         for dup_url in dup_urls:
-
+            filter_url = dup_url["url"]
+            print(f"FRemoving duplicates of video: {dup_url}")
             # 1. get video rows of all of the url instance
-            dups = Videos.objects.filter(dup_url)
+            dups = Videos.objects.filter(url=filter_url)
             assert len(dups) >= 1
-            # 2. decide on a particular url instance based on which has more info
+            # 2. Use the 1st video instance to hold all gathered info
+            # Use the first video as the defaults
+            dest_id: Videos = dups.first()
+            # Don't count destination video as a duplicate
+            dup_vid_ids_except_new = set(dup.id for dup in dups)
+            dup_vid_ids_except_new.remove(dest_id.id)
 
-            choice_made = False
-            dest_id: Optional[int] = dups.first().id
             title = dups.first().title
             category = dups.first().category
             channel = dups.first().channel
             description = dups.first().description
             keywords = dups.first().keywords
-            #Sum all counts?
-            watched_as_ad = dups.first().watched_as_ad
-            watched_as_video = dups.first().watched_as_ad
+
+            # Sum all counts
+            watched_as_ad = 0
+            watched_as_video = 0
             adfile_id = None
             checked: bool = False
             check_status = CheckStatus.NOT_CHECKED.value
@@ -45,8 +45,11 @@ class Command(BaseCommand):
                 if vid.AdFile_ID is not None:
                     # No duplicate adfile entries for same video
                     assert adfile_id is not None
-                    dest_id = vid.id
-                    AdFile_ID = vid.AdFile_ID
+                    dest_id = vid
+                    adfile_id = vid.AdFile_ID
+                    checked = True
+                    assert vid.check_status == "FOUND"
+                    check_status = vid.check_status
                 if vid.title != "":
                     title = vid.title
                 if vid.description != "":
@@ -54,17 +57,37 @@ class Command(BaseCommand):
                 if vid.keywords != "" or vid.keywords != "[]":
                     keywords = vid.keywords
                 watched_as_ad += vid.watched_as_ad
-                watched_as_video +=  vid.watched_as_video
+                watched_as_video += vid.watched_as_video
+                if vid.channel.id != missing_channel_id:
+                    channel = vid.channel
+                new_info = vid.category.id != missing_category_id
+                if new_info:
+                    category = vid.category
+
+            destination_video: Videos = Videos.objects.get(pk=dest_id.id)
+            destination_video.category = category
+            destination_video.channel = channel
+            destination_video.checked = checked
+            destination_video.check_status = check_status
+            destination_video.description = description
+            destination_video.AdFile_ID = adfile_id
+            destination_video.watched_as_video = watched_as_video
+            destination_video.watched_as_ad = watched_as_ad
+            destination_video.keywords = keywords
+            destination_video.title = title
+            print(f"updated video: Video: id={destination_video.id}, url={destination_video.url}")
+            destination_video.save()
+            # Replace the duplicate video ids in watchlog with single copy
+            Ad_Found_WatchLog.objects.filter(ad_video__in=dup_vid_ids_except_new).update(ad_video=dest_id)
+            Ad_Found_WatchLog.objects.filter(video_watched__in=dup_vid_ids_except_new).update(video_watched=dest_id)
 
 
-
-
-
-
+            # Delete all but single video copy
+            res = Videos.objects.filter(id__in=dup_vid_ids_except_new).delete()
+            print(f"{res=}")
 
             # 2a. In the case that one has an adfile fk move all the info from others to it.
             # 2b. If it none have an adfile fk, then choose the first which has the most info
 
             # 3. Get all the ad watchlogs which
-            break
         self.stdout.write(self.style.SUCCESS("Successfully printed a video url"))

--- a/processor/models.py
+++ b/processor/models.py
@@ -170,6 +170,9 @@ class Categories(models.Model):
 
     objects = CategoryManager()
 
+    def __repr__(self):
+        return f"<Categories({self.id}): cat_id={self.cat_id}, name={self.name}>"
+
     def mark_missing(self):
         self.cat_id = MISSING_ID
         self.name = MISSING_NAME
@@ -212,6 +215,9 @@ class Channels(models.Model):
     name = models.CharField(max_length=255)
     description = models.CharField(max_length=255, default='')
     objects = ChannelManager()
+
+    def __repr__(self):
+        return f"<Channels: id={self.id}, channel_id={self.channel_id}, name={self.name}, description={self.description}>"
 
     def is_external(self) -> bool:
         return self.name == EXTERNAL_NAME and self.channel_id == EXTERNAL_ID
@@ -284,12 +290,13 @@ class Videos(models.Model):
 
     objects = VideoManager()
     def __str__(self):
-        return self.__repr__()
+        return repr(self)
 
     def __repr__(self):
         return (f'{self.__class__.__name__}('
                 f'{self.id!r}, {self.url!r}'
                 f' {self.title!r}, {self.channel!r}'
+                f' {self.category!r}'
                 f' {self.description!r}, {self.keywords!r}'
                 f' {self.watched_as_ad!r}, {self.watched_as_video!r}'
                 f' {self.AdFile_ID!r}, {self.checked!r}'
@@ -309,3 +316,6 @@ class Ad_Found_WatchLog(models.Model):
     ad_duration = models.IntegerField(default=0)
     ad_skip_duration = models.IntegerField(default=0)
     ad_system = models.CharField(max_length=255, default='')
+
+    def __repr__(self):
+        return f"<AdFoundWatchLog({self.id}): batch={self.batch.id}, bot={self.bot.id}, video_watched={self.video_watched.id}, ad_video={self.ad_video.id}, {self.request_timestamp=}, {self.attempt=}"


### PR DESCRIPTION
Consolidate extra duplicate video entries in videos table (same url)
* If one has more info than the other, merge the info together. Such as having keywords vs another having no keywords
Updates the watchlog to reflect the 1st of the copies found
Remove extra video entries from videos table so only one copy of each url is left.
