### PR TITLE
Upgrade youtube-dl 2020.11.1.1 (Fixes JS YT url extraction)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ mysqlclient==2.0.1
 python-dateutil==2.8.1
 google-api-python-client==1.12.5
 requests==2.23.0
-youtube-dl==2020.9.20
+youtube-dl==2020.11.1.1
 beautifulsoup4==4.9.1
 tenacity==6.2.0
 lxml==4.5.1


### PR DESCRIPTION
From changelog
Extractors
* [youtube] Fix JS player URL extraction
