### PR TITLE
Processor improvements

### DIFF
--- a/CyadsProcessor/settings.py
+++ b/CyadsProcessor/settings.py
@@ -9,6 +9,16 @@ https://docs.djangoproject.com/en/2.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.0/ref/settings/
 """
+
+import sentry_sdk
+from sentry_sdk.integrations.django import \
+    DjangoIntegration
+
+sentry_sdk.init(
+    "https://48191e5cefcf429684d6b48f18749aae@o296293.ingest.sentry.io/5169399",
+    integrations=[DjangoIntegration()]
+)
+
 import datetime
 import os
 

--- a/CyadsProcessor/urls.py
+++ b/CyadsProcessor/urls.py
@@ -22,10 +22,7 @@ from rest_framework import routers
 from processor import views as processor_views
 
 from messaging.subscribers.batch_subscriber import BatchSubscriber
-from downloader.download import DownloadProcessor
-import downloader
-from downloader import views
-from processor.views import process, process_all, test
+from processor.views import process, process_all, test, test_error
 from ad_extension_pull.views import view_process_videos_collected_from_extension
 
 router = routers.DefaultRouter()
@@ -41,6 +38,7 @@ urlpatterns = [
     path("batch/<int:batch_id>/reprocess/", process, kwargs={'force': True}, name="reprocess"),
     path("process_all/", process_all, name="process_all"),
     path("test/<int:number>/", test, name="test"),
+    path("test/error/<str:err_msg>", test_error, name="test_error"),
     path("ad_extension_process_videos", view_process_videos_collected_from_extension, name="ad_extension_video_process"),
     url('^api/', include(router.urls)),
 ]

--- a/dashboard/templates/database_mb.html
+++ b/dashboard/templates/database_mb.html
@@ -3,7 +3,7 @@
   {% block title %}Cyads -{% endblock title %}
   <meta name="description" content="Comparison between local and Google cyads DB">
 </head>
-{% block title-vis %}DATABASE DETAILS{% endblock title-vis %}
+{% block title-vis %}DATABASE METRICS{% endblock title-vis %}
 {% block content %}
 
 <style>
@@ -31,9 +31,6 @@
 
 </style>
 
-<b>processor_ad_found_watchlog # Records (cyads.misc.iastate.edu):</b> {{ad_views_mb}}<br>
-<b>processor_ad_found_watchlog # (Records GCP SQL cyads-db):</b> {{ad_views_gcp_copy}}<br>
-
 <div id="tables">
   <div style="padding-right:3em">
   <h3>Mother Brain</h3>
@@ -41,16 +38,14 @@
       <thead>
         <tr>
           <th>Table Name</th>
-          <th>Size in MB</th>
-          <th>Estimated Records</th>
+          <th>Number of Records</th>
         </tr>
       </thead>
       <tbody>
       {% for table in mb_tables_info %}
         <tr>
           <td>{{table.table_name}}</td>
-          <td>{{table.data_size_mb}}</td>
-          <td>{{table.rows_estimate}}</td>
+          <td>{{table.record_count}}</td>
       </tr>
         {% endfor %}
       </tbody>
@@ -62,16 +57,14 @@
       <thead>
         <tr>
           <th>Table Name</th>
-          <th>Size in MB</th>
-          <th>Estimated Records</th>
+          <th>Number of Records</th>
         </tr>
       </thead>
       <tbody>
       {% for table in gcp_copy_tables_info %}
         <tr>
           <td>{{table.table_name}}</td>
-          <td>{{table.data_size_mb}}</td>
-          <td>{{table.rows_estimate}}</td>
+          <td>{{table.record_count}}</td>
       </tr>
         {% endfor %}
       </tbody>

--- a/downloader/tasks.py
+++ b/downloader/tasks.py
@@ -117,15 +117,12 @@ def video_download(url: str, download_dir: str) -> Path:
     mylogger = MyLogger()
 
     ydl_opts = {
-        # Pick best audio and video format and combine them OR pick the file with the best combination
-        # Need to capture filename of merged ffmpeg file
-        # Best doesn't return the highest video, only the highest pair.
-        # So 360p video may have the highest audio
-        # 'format': 'best',
-        # 'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo[ext=webm]+bestaudio[ext=webm]/best',
-        #'format': 'bestvideo+bestaudio/best',
+        # Only download mp4 Videos
+        'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/mp4',
+        'merge_output_format': 'mp4',
         'nooverwrites': True,
         # 'continuedl': True,
+        # Need to capture filename of merged ffmpeg file
         'progress_hooks': [my_hook],
         'logger': mylogger,
     }

--- a/processor/views.py
+++ b/processor/views.py
@@ -75,6 +75,10 @@ def test(request, number: int):
     return HttpResponse(f"Server active: Got number: {number}")
 
 
+def test_error(request, err_msg: str):
+    raise Exception(f"test error reporting - msg: {err_msg}")
+
+
 class BatchViewSet(viewsets.ModelViewSet):
 
     def batches_with_datetime():

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ docutils
 djangorestframework==3.11.1
 djangorestframework-datatables==0.5.2
 serpy==0.3.1
+sentry-sdk==0.20.1

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
         "video_metadata @ git+https://github.com/cml-cs-iastate/video_metadata",
         "structlog==20.1.0",
         "docutils",
+        "serpy>=0.3",
+        "sentry==0.20.1",
     ],
     packages=find_namespace_packages(),
 )


### PR DESCRIPTION
Make the dashboard MB -> GCP use exact record counts.
Only display columns that are end results of sync process (less scanning for a particular column)

Only download mp4 videos in downloader.